### PR TITLE
Registra flag para prevenir sobrecarga de processamento

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -50,6 +50,7 @@ class Plugin extends \MapasCulturais\Plugin {
     }
     
     public function register() {
+        $this->registerUserMetadata(Provider::$preventNotifications, ['label' => i::__('Não receber notificações')]);
         $this->registerUserMetadata(Provider::$passMetaName, ['label' => i::__('Senha')]);
         $this->registerUserMetadata(Provider::$recoverTokenMetadata, ['label' => i::__('Token para recuperação de senha')]);
         $this->registerUserMetadata(Provider::$recoverTokenTimeMetadata, ['label' => i::__('Timestamp do token para recuperação de senha')]);

--- a/Plugin.php
+++ b/Plugin.php
@@ -50,7 +50,7 @@ class Plugin extends \MapasCulturais\Plugin {
     }
     
     public function register() {
-        $this->registerUserMetadata(Provider::$preventNotifications, ['label' => i::__('Não receber notificações')]);
+        $this->registerUserMetadata(Provider::$preventOverhead, ['label' => i::__('Evitar tarefas que geram sobrecarga de processamento')]);
         $this->registerUserMetadata(Provider::$passMetaName, ['label' => i::__('Senha')]);
         $this->registerUserMetadata(Provider::$recoverTokenMetadata, ['label' => i::__('Token para recuperação de senha')]);
         $this->registerUserMetadata(Provider::$recoverTokenTimeMetadata, ['label' => i::__('Timestamp do token para recuperação de senha')]);

--- a/Provider.php
+++ b/Provider.php
@@ -22,7 +22,8 @@ class Provider extends \MapasCulturais\AuthProvider {
 
     public static $recoverTokenMetadata     = 'recover_token';
     public static $recoverTokenTimeMetadata = 'recover_token_time';
-    public static $preventNotifications = 'prevent_notifications';
+
+    public static $preventOverhead = 'preventOverhead';
     
     public static $accountIsActiveMetadata    = 'accountIsActive';
     public static $tokenVerifyAccountMetadata = 'tokenVerifyAccount';

--- a/Provider.php
+++ b/Provider.php
@@ -22,6 +22,7 @@ class Provider extends \MapasCulturais\AuthProvider {
 
     public static $recoverTokenMetadata     = 'recover_token';
     public static $recoverTokenTimeMetadata = 'recover_token_time';
+    public static $preventNotifications = 'prevent_notifications';
     
     public static $accountIsActiveMetadata    = 'accountIsActive';
     public static $tokenVerifyAccountMetadata = 'tokenVerifyAccount';


### PR DESCRIPTION
### Contexto

No ambiente de grande volume de informações, como no Ministério da Cultura, verificamos usuários particulares que atraem para si excessiva carga de processamento resultando em timeout e quebra de contuidade dos trabalhos, a exemplo da Secretaria de Cidadania e Diversidade Cultural (SCDC) do Ministério da Cultura que não conseguia completar o login por agregar milhares de agentes.

### Intervenção

Como alternativa, criamos uma _flag_ chamada "**preventOverhead**" em banco de dados e a registramos durante o login para que esteja disponível para outros módulos em tempo de execução e seja facilmente acessada se necessário.

A princípio, para resolver as dificuldades da SCDC, ativamos esta _flag_ apenas para o usuário correspondente à SCDC e implementamos a verificação desta _flag_ antes de duas tarefas específicas:
* Notificação de perfis desatualizados;
* Recriação de permissões.  